### PR TITLE
Replace Flag with GoOpt

### DIFF
--- a/gofigure.go
+++ b/gofigure.go
@@ -1,27 +1,27 @@
 package gofigure
 
 import (
-	"flag"
+	"github.com/droundy/goopt"
 	"os"
 )
-
-// Pointer to the default set of command line flags.
-var set *flag.FlagSet
 
 // Config contains the configuration options that may be set by
 // command line flags and environment variables.
 type Config struct {
-	EnvPrefix string
-	options   map[string]*Option
-	values    map[string]*string
+	Description string
+	Version     string
+	EnvPrefix   string
+	options     map[string]*Option
+	flags       map[string]*string
+	values		map[string]string
 }
 
 // Returns a new Config instance.
 func New() *Config {
-	set = flag.CommandLine
 	return &Config{
 		options: make(map[string]*Option),
-		values:  make(map[string]*string),
+		flags:  make(map[string]*string),
+		values: make(map[string]string),
 	}
 }
 
@@ -38,7 +38,7 @@ func (c *Config) Add(name string) *Option {
 }
 
 // Returns a configuration option by flag name.
-func (c *Config) Get(name string) *string {
+func (c *Config) Get(name string) string {
 	return c.values[name]
 }
 
@@ -49,45 +49,49 @@ func (c *Config) Get(name string) *string {
 //
 // See https://github.com/rakyll/globalconf/blob/master/globalconf.go
 func (c *Config) Parse() {
+	goopt.Description = func() string {
+		return c.Description 
+	}
+
+	goopt.Version = c.Version
 
 	// Sets the flags from the configuration options.
 	for name, o := range c.options {
-		c.values[name] = flag.String(name, o.def, o.desc)
+		c.flags[name] = goopt.String([]string{"--"+name}, "", o.desc)
+		c.values[name] = o.def
 	}
 
-	flag.Parse()
+	goopt.Parse(nil)
 
 	// Gather the flags passed through command line.
 	passed := make(map[string]bool)
-	set.Visit(func(f *flag.Flag) {
-		passed[f.Name] = true
-	})
+	for name, f := range c.flags {
+		if *f != "" {
+			passed[name] = true
+			c.values[name] = *f
+		}
+	}
 
-	set.VisitAll(func(f *flag.Flag) {
+	for name, f := range c.options {
 
 		// Skip flags passed through the command line as the option is
 		// already set and takes precedence over environment variables.
-		if passed[f.Name] {
-			return
-		}
-
-		// Skip flags that aren't added to Config.
-		if _, isset := c.options[f.Name]; !isset {
+		if passed[name] {
 			return
 		}
 
 		// Some options shouldn't be set via environment variables.
-		if c.options[f.Name].envVar == "" {
+		if f.envVar == "" {
 			return
 		}
 
 		// If the configuration option was not passed via the command line,
 		// check the corresponding environment variable.
-		envVar := c.EnvPrefix + c.options[f.Name].envVar
+		envVar := c.EnvPrefix + f.envVar
 		if val := os.Getenv(envVar); val != "" {
-			set.Set(f.Name, val)
+			c.values[name] = val
 		}
-	})
+	}
 }
 
 // Option contains the details of a configuration options,

--- a/gofigure.go
+++ b/gofigure.go
@@ -88,12 +88,12 @@ func (c *Config) Parse() {
 		// Skip flags passed through the command line as the option is
 		// already set and takes precedence over environment variables.
 		if passed[name] {
-			return
+			continue
 		}
 
 		// Some options shouldn't be set via environment variables.
 		if f.envVar == "" {
-			return
+			continue
 		}
 
 		// If the configuration option was not passed via the command line,

--- a/gofigure.go
+++ b/gofigure.go
@@ -8,20 +8,22 @@ import (
 // Config contains the configuration options that may be set by
 // command line flags and environment variables.
 type Config struct {
-	Description	string
-	Version		string
-	EnvPrefix	string
-	options		map[string]*Option
-	flags		map[string]*string
-	values		map[string]string
+	Description			string
+	DisableCommandLine	bool
+	Version				string
+	EnvPrefix			string
+	options				map[string]*Option
+	flags				map[string]*string
+	values				map[string]string
 }
 
 // Returns a new Config instance.
 func New() *Config {
 	return &Config{
-		options: make(map[string]*Option),
-		flags:  make(map[string]*string),
-		values: make(map[string]string),
+		DisableCommandLine:	false,
+		options:			make(map[string]*Option),
+		flags:				make(map[string]*string),
+		values:				make(map[string]string),
 	}
 }
 
@@ -57,18 +59,26 @@ func (c *Config) Parse() {
 
 	// Sets the flags from the configuration options.
 	for name, o := range c.options {
-		c.flags[name] = goopt.String([]string{"--"+name}, "", o.desc)
+		cmdline := []string{}
+		if o.shortOpt != "" {
+			cmdline = append(cmdline, "-" + o.shortOpt)
+		}
+		cmdline = append(cmdline, "--"+name)
+		c.flags[name] = goopt.String(cmdline, "", o.desc)
 		c.values[name] = o.def
 	}
 
-	goopt.Parse(nil)
-
-	// Gather the flags passed through command line.
 	passed := make(map[string]bool)
-	for name, f := range c.flags {
-		if *f != "" {
-			passed[name] = true
-			c.values[name] = *f
+
+	if !c.DisableCommandLine {
+		goopt.Parse(nil)
+
+		// Gather the options passed through command line.
+		for name, f := range c.flags {
+			if *f != "" {
+				passed[name] = true
+				c.values[name] = *f
+			}
 		}
 	}
 
@@ -98,7 +108,12 @@ func (c *Config) Parse() {
 // e.g. corresponding environment variable, default value,
 // description.
 type Option struct {
-	envVar, def, desc string
+	envVar, shortOpt, def, desc string
+}
+
+func (o *Option) ShortOpt(opt string) *Option {
+	o.shortOpt = opt
+	return o
 }
 
 // Sets the configuration option's default value.

--- a/gofigure.go
+++ b/gofigure.go
@@ -8,11 +8,11 @@ import (
 // Config contains the configuration options that may be set by
 // command line flags and environment variables.
 type Config struct {
-	Description string
-	Version     string
-	EnvPrefix   string
-	options     map[string]*Option
-	flags       map[string]*string
+	Description	string
+	Version		string
+	EnvPrefix	string
+	options		map[string]*Option
+	flags		map[string]*string
 	values		map[string]string
 }
 

--- a/gofigure.go
+++ b/gofigure.go
@@ -14,7 +14,7 @@ type Config struct {
 	EnvPrefix			string
 	options				map[string]*Option
 	flags				map[string]*string
-	values				map[string]string
+	values				map[string]*string
 }
 
 // Returns a new Config instance.
@@ -23,7 +23,7 @@ func New() *Config {
 		DisableCommandLine:	false,
 		options:			make(map[string]*Option),
 		flags:				make(map[string]*string),
-		values:				make(map[string]string),
+		values:				make(map[string]*string),
 	}
 }
 
@@ -40,7 +40,7 @@ func (c *Config) Add(name string) *Option {
 }
 
 // Returns a configuration option by flag name.
-func (c *Config) Get(name string) string {
+func (c *Config) Get(name string) *string {
 	return c.values[name]
 }
 
@@ -65,7 +65,8 @@ func (c *Config) Parse() {
 		}
 		cmdline = append(cmdline, "--"+name)
 		c.flags[name] = goopt.String(cmdline, "", o.desc)
-		c.values[name] = o.def
+		defcopy := o.def
+		c.values[name] = &defcopy
 	}
 
 	passed := make(map[string]bool)
@@ -77,7 +78,7 @@ func (c *Config) Parse() {
 		for name, f := range c.flags {
 			if *f != "" {
 				passed[name] = true
-				c.values[name] = *f
+				*c.values[name] = *f
 			}
 		}
 	}
@@ -99,7 +100,7 @@ func (c *Config) Parse() {
 		// check the corresponding environment variable.
 		envVar := c.EnvPrefix + f.envVar
 		if val := os.Getenv(envVar); val != "" {
-			c.values[name] = val
+			*c.values[name] = val
 		}
 	}
 }

--- a/gofigure_test.go
+++ b/gofigure_test.go
@@ -17,7 +17,7 @@ func TestParse(t *testing.T) {
 
 	config.Parse()
 
-	listen := *config.Get("listen")
+	listen := config.Get("listen")
 	if listen != ":3001" {
 		t.Errorf("Flag 'listen' found %v, expected :3001", listen)
 	}

--- a/gofigure_test.go
+++ b/gofigure_test.go
@@ -15,6 +15,7 @@ func TestParse(t *testing.T) {
 
 	config.Add("listen").EnvVar("LISTEN").Default(":3000")
 
+	config.DisableCommandLine = true
 	config.Parse()
 
 	listen := config.Get("listen")

--- a/gofigure_test.go
+++ b/gofigure_test.go
@@ -18,7 +18,7 @@ func TestParse(t *testing.T) {
 	config.DisableCommandLine = true
 	config.Parse()
 
-	listen := config.Get("listen")
+	listen := *config.Get("listen")
 	if listen != ":3001" {
 		t.Errorf("Flag 'listen' found %v, expected :3001", listen)
 	}


### PR DESCRIPTION
Flag is a rather simple library, but it works in sort of a special snowflake way. GoOpt, however, is more compliant to standards, and has the ability to generate --help and manpages by default without any additional input. This pull request moves the command line options from flag to goopt.

Potentially breaking changes:
- In a standards-compliant way, long options are now enforced to be marked with --. I'm not sure if that was the case before.
- Config.Get() now returns a string instead of a pointer to a string. There was no discernible reason to use pointers for the actual calculated values. Tell me if I'm wrong on this count and I'll reverse this.

Tests are updated to reflect this change. Keystore will probably break on merge.