### PR TITLE
Add files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: go
 go:
   - 1.2
   - 1.3
+  - 1.4
   - tip

--- a/file.go
+++ b/file.go
@@ -1,0 +1,114 @@
+package gofigure
+
+import (
+	"log"
+	"strings"
+)
+
+type CategoryMap map[string]*Category
+type ValueMap map[string]string
+
+type Category struct {
+	Name		string
+	Parent		*Category
+	Categories	CategoryMap
+	Values		ValueMap
+}
+
+func NewCategory(name string, parent *Category) *Category {
+	return &Category {
+		Name:       name,
+		Parent:     parent,
+		Categories: CategoryMap{},
+		Values:     ValueMap{},
+	}
+}
+
+func (c Category) FindOption(o *Option) (string, bool) {
+	if o.fileSpec != "" {
+		val, ok := c.Find(o.fileSpec)
+		return val, ok
+	}
+	return "", false
+}
+
+func (c Category) Find(spec string) (string, bool) {
+	fs := strings.Split(spec, ".")
+	if len(fs) > 1 {
+		next := c.Categories.Get(fs[0])
+		if next != nil {
+			n, e := next.Find(strings.Join(fs[1:], "."))
+			return n, e
+		} else {
+			return "", false
+		}
+	} else {
+		return c.Values.Get(fs[0]), c.Values.Exists(fs[0])
+	}
+}
+
+func (c CategoryMap) Exists(key string) bool {
+	if _, ok := c[key]; ok {
+		return true
+	}
+	return false
+}
+
+func (c CategoryMap) MustGet(key string) *Category {
+	if v, ok := c[key]; ok {
+		return v
+	}
+	log.Panicf("Undefined required category %s.", key)
+	return nil
+}
+
+func (c CategoryMap) Get(key string) *Category {
+	if v, ok := c[key]; ok {
+		return v
+	}
+	return nil
+}
+
+func (c CategoryMap) Set(key string, value *Category) {
+	c[key] = value
+}
+
+func (c CategoryMap) Delete(key string) {
+	delete(c, key)
+}
+
+func (c ValueMap) Exists(key string) bool {
+	if _, ok := c[key]; ok {
+		return true
+	}
+	return false
+}
+
+func (c ValueMap) MustGet(key string) string {
+	if v, ok := c[key]; ok {
+		return v
+	}
+	log.Panicf("Undefined required value %s.", key)
+	return ""
+}
+
+func (c ValueMap) Get(key string) string {
+	if v, ok := c[key]; ok {
+		return v
+	}
+	return ""
+}
+
+func (c ValueMap) Set(key, value string) {
+	c[key] = value
+}
+
+func (c ValueMap) Delete(key string) {
+	delete(c, key)
+}
+
+
+type File interface {
+	Parse(name string) (*Category, error)
+	ParseConfig(name string, specs map[string]*Option) (ValueMap, error)
+}

--- a/file.go
+++ b/file.go
@@ -1,6 +1,7 @@
 package gofigure
 
 import (
+	"fmt"
 	"log"
 	"strings"
 )
@@ -30,6 +31,15 @@ func (c Category) FindOption(o *Option) (string, bool) {
 		return val, ok
 	}
 	return "", false
+}
+
+func (c Category) Print(indent string) {
+	fmt.Printf("%sCategories = [\n", indent)
+	c.Categories.Print(fmt.Sprintf("%s  ", indent))
+	fmt.Printf("%s]\n", indent)
+	fmt.Printf("%sValues = [\n", indent)
+	c.Values.Print(fmt.Sprintf("%s  ", indent))
+	fmt.Printf("%s]\n", indent)
 }
 
 func (c Category) Find(spec string) (string, bool) {
@@ -77,6 +87,14 @@ func (c CategoryMap) Delete(key string) {
 	delete(c, key)
 }
 
+func (c CategoryMap) Print(indent string) {
+	for k, v := range c {
+		fmt.Printf("%s%s: Category {\n", indent, k)
+		v.Print(fmt.Sprintf("%s  ", indent))
+		fmt.Printf("}\n")
+	}
+}
+
 func (c ValueMap) Exists(key string) bool {
 	if _, ok := c[key]; ok {
 		return true
@@ -107,7 +125,12 @@ func (c ValueMap) Delete(key string) {
 	delete(c, key)
 }
 
+func (c ValueMap) Print(indent string) {
+	for k, v := range c {
+		fmt.Printf("%s%s: %s\n", indent, k, v)
+	}
+}
 
 type File interface {
-	Parse(name string) (*Category, error)
+	Parse() (*Category, error)
 }

--- a/file.go
+++ b/file.go
@@ -110,5 +110,4 @@ func (c ValueMap) Delete(key string) {
 
 type File interface {
 	Parse(name string) (*Category, error)
-	ParseConfig(name string, specs map[string]*Option) (ValueMap, error)
 }

--- a/gofigure.go
+++ b/gofigure.go
@@ -8,20 +8,22 @@ import (
 // Config contains the configuration options that may be set by
 // command line flags and environment variables.
 type Config struct {
-	Description	string
-	Version		string
-	EnvPrefix	string
-	options		map[string]*Option
-	flags		map[string]*string
-	values		map[string]string
+	Description			string
+	DisableCommandLine	bool
+	Version				string
+	EnvPrefix			string
+	options				map[string]*Option
+	flags				map[string]*string
+	values				map[string]string
 }
 
 // Returns a new Config instance.
 func New() *Config {
 	return &Config{
-		options: make(map[string]*Option),
-		flags:  make(map[string]*string),
-		values: make(map[string]string),
+		DisableCommandLine:	false,
+		options:			make(map[string]*Option),
+		flags:				make(map[string]*string),
+		values:				make(map[string]string),
 	}
 }
 
@@ -57,18 +59,26 @@ func (c *Config) Parse() {
 
 	// Sets the flags from the configuration options.
 	for name, o := range c.options {
-		c.flags[name] = goopt.String([]string{"--"+name}, "", o.desc)
+		cmdline := []string{}
+		if o.shortOpt != "" {
+			cmdline = append(cmdline, "-" + o.shortOpt)
+		}
+		cmdline = append(cmdline, "--"+name)
+		c.flags[name] = goopt.String(cmdline, "", o.desc)
 		c.values[name] = o.def
 	}
 
-	goopt.Parse(nil)
-
-	// Gather the flags passed through command line.
 	passed := make(map[string]bool)
-	for name, f := range c.flags {
-		if *f != "" {
-			passed[name] = true
-			c.values[name] = *f
+
+	if !c.DisableCommandLine {
+		goopt.Parse(nil)
+
+		// Gather the options passed through command line.
+		for name, f := range c.flags {
+			if *f != "" {
+				passed[name] = true
+				c.values[name] = *f
+			}
 		}
 	}
 
@@ -98,7 +108,12 @@ func (c *Config) Parse() {
 // e.g. corresponding environment variable, default value,
 // description.
 type Option struct {
-	envVar, def, desc string
+	envVar, shortOpt, def, desc string
+}
+
+func (o *Option) ShortOpt(opt string) *Option {
+	o.shortOpt = opt
+	return o
 }
 
 // Sets the configuration option's default value.

--- a/gofigure.go
+++ b/gofigure.go
@@ -32,6 +32,7 @@ func New() *Config {
 // value, and description.
 func (c *Config) Add(name string) *Option {
 	c.options[name] = &Option{
+		name:   name,
 		envVar: "",
 		def:    "",
 		desc:   "",
@@ -109,7 +110,12 @@ func (c *Config) Parse() {
 // e.g. corresponding environment variable, default value,
 // description.
 type Option struct {
-	envVar, shortOpt, def, desc string
+	name, envVar, shortOpt, def, desc string
+	fileSpec				string              // The file spec is of the form "(CATEGORY.)*NAME", eg. for 'foo' under the category 'bar', it would be foo.bar
+}
+
+func (o Option) Name() string {
+	return o.name
 }
 
 func (o *Option) ShortOpt(opt string) *Option {

--- a/gofigure.go
+++ b/gofigure.go
@@ -14,7 +14,7 @@ type Config struct {
 	EnvPrefix			string
 	options				map[string]*Option
 	flags				map[string]*string
-	values				map[string]string
+	values				map[string]*string
 }
 
 // Returns a new Config instance.
@@ -23,7 +23,7 @@ func New() *Config {
 		DisableCommandLine:	false,
 		options:			make(map[string]*Option),
 		flags:				make(map[string]*string),
-		values:				make(map[string]string),
+		values:				make(map[string]*string),
 	}
 }
 
@@ -40,7 +40,7 @@ func (c *Config) Add(name string) *Option {
 }
 
 // Returns a configuration option by flag name.
-func (c *Config) Get(name string) string {
+func (c *Config) Get(name string) *string {
 	return c.values[name]
 }
 
@@ -65,7 +65,8 @@ func (c *Config) Parse() {
 		}
 		cmdline = append(cmdline, "--"+name)
 		c.flags[name] = goopt.String(cmdline, "", o.desc)
-		c.values[name] = o.def
+		defcopy := o.def
+		c.values[name] = &defcopy
 	}
 
 	passed := make(map[string]bool)
@@ -77,7 +78,7 @@ func (c *Config) Parse() {
 		for name, f := range c.flags {
 			if *f != "" {
 				passed[name] = true
-				c.values[name] = *f
+				*c.values[name] = *f
 			}
 		}
 	}
@@ -99,7 +100,7 @@ func (c *Config) Parse() {
 		// check the corresponding environment variable.
 		envVar := c.EnvPrefix + f.envVar
 		if val := os.Getenv(envVar); val != "" {
-			c.values[name] = val
+			*c.values[name] = val
 		}
 	}
 }

--- a/gofigure_test.go
+++ b/gofigure_test.go
@@ -6,8 +6,10 @@ import (
 )
 
 const envPrefixTest = "TEST_"
+const jsonTestFixture = "test_fixture.json"
+const fileSpecTest = "main_category.listen"
 
-func TestParse(t *testing.T) {
+func TestEnv(t *testing.T) {
 	os.Setenv(envPrefixTest+"LISTEN", ":3001")
 
 	config := New()
@@ -23,3 +25,52 @@ func TestParse(t *testing.T) {
 		t.Errorf("Flag 'listen' found %v, expected :3001", listen)
 	}
 }
+
+func TestJsonFile(t *testing.T) {
+	config := New()
+	config.FileParser = NewJsonFile(jsonTestFixture)
+
+	config.Add("listen").FileSpec(fileSpecTest).Default(":3000")
+	config.DisableCommandLine = true
+	config.Parse()
+
+	listen := *config.Get("listen")
+	if listen != ":3002" {
+		t.Errorf("Flag 'listen' found %v, expected :3002", listen)
+	}
+}
+
+func TestPrecedenceEnv(t *testing.T) {
+	os.Setenv(envPrefixTest+"LISTEN", ":3001")
+	config := New()
+	config.FileParser = NewJsonFile(jsonTestFixture)
+	config.EnvOverridesFile = true
+	config.EnvPrefix = envPrefixTest
+
+	config.Add("listen").FileSpec(fileSpecTest).EnvVar("LISTEN").Default(":3000")
+	config.DisableCommandLine = true
+	config.Parse()
+
+	listen := *config.Get("listen")
+	if listen != ":3001" {
+		t.Errorf("Flag 'listen' found %v, expected :3001", listen)
+	}
+}
+
+func TestPrecedenceFile(t *testing.T) {
+	os.Setenv(envPrefixTest+"LISTEN", ":3001")
+	config := New()
+	config.FileParser = NewJsonFile(jsonTestFixture)
+	config.EnvOverridesFile = false
+	config.EnvPrefix = envPrefixTest
+
+	config.Add("listen").FileSpec(fileSpecTest).EnvVar("LISTEN").Default(":3000")
+	config.DisableCommandLine = true
+	config.Parse()
+
+	listen := *config.Get("listen")
+	if listen != ":3002" {
+		t.Errorf("Flag 'listen' found %v, expected :3002", listen)
+	}
+}
+

--- a/gofigure_test.go
+++ b/gofigure_test.go
@@ -15,6 +15,7 @@ func TestParse(t *testing.T) {
 
 	config.Add("listen").EnvVar("LISTEN").Default(":3000")
 
+	config.DisableCommandLine = true
 	config.Parse()
 
 	listen := config.Get("listen")

--- a/gofigure_test.go
+++ b/gofigure_test.go
@@ -18,7 +18,7 @@ func TestParse(t *testing.T) {
 	config.DisableCommandLine = true
 	config.Parse()
 
-	listen := config.Get("listen")
+	listen := *config.Get("listen")
 	if listen != ":3001" {
 		t.Errorf("Flag 'listen' found %v, expected :3001", listen)
 	}

--- a/jsonfile.go
+++ b/jsonfile.go
@@ -1,0 +1,75 @@
+package gofigure
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"strconv"
+)
+
+type JsonFile struct {}
+
+func (j JsonFile) ProcessLayer(layer map[string]interface{}, name string, parent *Category) (*Category, error) {
+	current := NewCategory(name, parent)
+
+	for k, v := range layer {
+		switch v.(type) {
+		case string:
+			current.Values.Set(k, v.(string))
+		case float64:
+			current.Values.Set(k, strconv.FormatFloat(v.(float64), 'f', -1, 64))
+		case bool:
+			b := v.(bool)
+			if (b) {
+				current.Values.Set(k, "true")
+			} else {
+				current.Values.Set(k, "false")
+			}
+		case []interface{}:
+			// Lists are pretty complicated to handle. I'll leave this for right now and implement it if required.
+			current.Values.Set(k ,"{{list}}")
+		case map[string]interface{}:
+			c, err := j.ProcessLayer(v.(map[string]interface{}), k, current)
+			if err != nil {
+				return nil, err
+			}
+			current.Categories.Set(k, c)
+		// According to the json specs, this should only be 'null'.
+		// default:
+		//		current.Values.Set(k, "{{null}}")
+		}
+	}
+	return current, nil
+}
+
+func (j JsonFile) Parse(name string) (*Category, error) {
+	data := map[string]interface{}{}
+	bytes, err := ioutil.ReadFile(name)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(bytes, data)
+	if err != nil {
+		return nil, err
+	}
+
+	root, err := j.ProcessLayer(data, "/", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return root, nil
+}
+
+func (j JsonFile) ParseConfig(name string, specs map[string]*Option) (ValueMap, error) {
+	root, err := j.Parse(name)
+	if err != nil {
+		return nil, err
+	}
+	ret := ValueMap{}
+	for _, opt := range specs {
+		if val, ok := root.FindOption(opt); ok {
+			ret.Set(opt.Name(), val)
+		}
+	}
+	return ret, nil
+}

--- a/jsonfile.go
+++ b/jsonfile.go
@@ -59,17 +59,3 @@ func (j JsonFile) Parse(name string) (*Category, error) {
 
 	return root, nil
 }
-
-func (j JsonFile) ParseConfig(name string, specs map[string]*Option) (ValueMap, error) {
-	root, err := j.Parse(name)
-	if err != nil {
-		return nil, err
-	}
-	ret := ValueMap{}
-	for _, opt := range specs {
-		if val, ok := root.FindOption(opt); ok {
-			ret.Set(opt.Name(), val)
-		}
-	}
-	return ret, nil
-}

--- a/jsonfile.go
+++ b/jsonfile.go
@@ -2,11 +2,20 @@ package gofigure
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"strconv"
 )
 
-type JsonFile struct {}
+type JsonFile struct {
+	Filename string
+}
+
+func NewJsonFile(name string) *JsonFile {
+	return &JsonFile {
+		Filename: name,
+	}
+}
 
 func (j JsonFile) ProcessLayer(layer map[string]interface{}, name string, parent *Category) (*Category, error) {
 	current := NewCategory(name, parent)
@@ -30,7 +39,7 @@ func (j JsonFile) ProcessLayer(layer map[string]interface{}, name string, parent
 		case map[string]interface{}:
 			c, err := j.ProcessLayer(v.(map[string]interface{}), k, current)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("JsonFile.ProcessLayer: %s", err.Error())
 			}
 			current.Categories.Set(k, c)
 		// According to the json specs, this should only be 'null'.
@@ -41,20 +50,20 @@ func (j JsonFile) ProcessLayer(layer map[string]interface{}, name string, parent
 	return current, nil
 }
 
-func (j JsonFile) Parse(name string) (*Category, error) {
+func (j JsonFile) Parse() (*Category, error) {
 	data := map[string]interface{}{}
-	bytes, err := ioutil.ReadFile(name)
+	bytes, err := ioutil.ReadFile(j.Filename)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("JsonFile.Parse: Readfile failed - %s", err.Error())
 	}
-	err = json.Unmarshal(bytes, data)
+	err = json.Unmarshal(bytes, &data)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("JsonFile.Parse: Unmarshal failed - %s", err.Error())
 	}
 
 	root, err := j.ProcessLayer(data, "/", nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("JsonFile.Parse: ProcessLayer failed - %s", err.Error())
 	}
 
 	return root, nil

--- a/test_fixture.json
+++ b/test_fixture.json
@@ -1,0 +1,5 @@
+{
+	"main_category": {
+		"listen": ":3002"
+	}
+}


### PR DESCRIPTION
Adds the ability to specify a configuration file. By default, configuration files are not considered, they must be explicitly specified.

To specify a configuration file, set the FileHandler of an instance of Config to any valid object implementing the gofigure.File interface. Only configuration options whose FileSpec is specified are extracted from configuration files. A 'file spec' for a configuration option matches the regex (?P<CATEGORY>[^.]+.)*(?P<KEY>). For example, a specification could be 'options.video.resolution', which would extract the 'resolution' key from the 'video' subcategory of category 'options'.

This pull request comes with an example implementation of file, JsonFile, which can be used to extract information of any type as a string from a JSON file. Each JSON object is a category, which can contain 
any amount of categories (objects) or values (primitive types - string, number or boolean).

The JSON file functionality is tested.

By default, the configuration file takes precedence over the environment. This can be reversed by a flag on the Config object. Feel free to alter this, the tests do not depend on its default value.