### PR TITLE
fixing a mistake in a printed message

### DIFF
--- a/gofigure.go
+++ b/gofigure.go
@@ -90,7 +90,7 @@ func (c *Config) Parse() {
 		cmdline = append(cmdline, "--"+o.longOpt)
 		desc := o.desc
 		if c.DescribeEnvironment && o.envVar != "" {
-			desc += fmt.Sprintf(" Environment variable: %s_%s.", c.EnvPrefix, o.envVar)
+			desc += fmt.Sprintf(" Environment variable: %s%s.", c.EnvPrefix, o.envVar)
 		}
 		c.flags[name] = GooptFigureString(cmdline, o.def, desc)
 		defcopy := o.def


### PR DESCRIPTION
Fixing an error with self-documentation which lead to the environment variable being printed with an extra underscore.